### PR TITLE
Android always says that this is a rooted phone

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
+++ b/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
@@ -85,15 +85,19 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
 
   // executes a command on the system
   private static boolean canExecuteCommand(String command) {
-    boolean executedSuccesfully;
+    boolean executeResult;
     try {
-      Runtime.getRuntime().exec(command);
-      executedSuccesfully = true;
+      Process process = Runtime.getRuntime().exec(command);
+      if(process.waitFor() == 0) {
+        executeResult = true;
+      } else {
+        executeResult = false;
+      }
     } catch (Exception e) {
-      executedSuccesfully = false;
+      executeResult = false;
     }
-
-    return executedSuccesfully;
+ 
+    return executeResult;
   }
 
   //returns true if mock location enabled, false if not enabled.


### PR DESCRIPTION
Some android devices always return 'rooted phone' because of canExecuteCommand method. process waitFor functionality added to function.