### PR TITLE
Remove test-keys root check methods

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
+++ b/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
@@ -69,13 +69,6 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
     return false;
   }
 
-  private boolean containsTestKeys() {
-    // Get from build info
-    String buildTags = android.os.Build.TAGS;
-
-    return buildTags != null && buildTags.contains("test-keys");
-  }
-
   /**
    * Checks if the device is rooted.
    *
@@ -83,16 +76,11 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
    */
   private boolean isJailBroken() {
     if (android.os.Build.VERSION.SDK_INT >= 23) {
-      return checkRootMethod1() || checkRootMethod2() || checkRootMethod3();
+      return checkRootMethod2() || checkRootMethod3();
     } else {
-      return containsTestKeys() || isSuperuserPresent() || canExecuteCommand("/system/xbin/which su");
+      return isSuperuserPresent() || canExecuteCommand("/system/xbin/which su");
     }
   }
-
-	private static boolean checkRootMethod1() {
-	    String buildTags = android.os.Build.TAGS;
-	    return buildTags != null && buildTags.contains("test-keys");
-	}
 
 	private static boolean checkRootMethod2() {
 	    String[] paths = { "/system/app/Superuser.apk", "/sbin/su", "/system/bin/su", "/system/xbin/su", "/data/local/xbin/su", "/data/local/bin/su", "/system/sd/xbin/su",

--- a/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
+++ b/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
@@ -76,13 +76,13 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
    */
   private boolean isJailBroken() {
     if (android.os.Build.VERSION.SDK_INT >= 23) {
-      return checkRootMethod2() || checkRootMethod3();
+      return checkRootMethod1() || checkRootMethod2();
     } else {
       return isSuperuserPresent() || canExecuteCommand("/system/xbin/which su");
     }
   }
 
-	private static boolean checkRootMethod2() {
+	private static boolean checkRootMethod1() {
 	    String[] paths = { "/system/app/Superuser.apk", "/sbin/su", "/system/bin/su", "/system/xbin/su", "/data/local/xbin/su", "/data/local/bin/su", "/system/sd/xbin/su",
 	            "/system/bin/failsafe/su", "/data/local/su" };
 	    for (String path : paths) {
@@ -91,7 +91,7 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
 	    return false;
 	}
 
-	private static boolean checkRootMethod3() {
+	private static boolean checkRootMethod2() {
 	    Process process = null;
 	    try {
 	        process = Runtime.getRuntime().exec(new String[] { "/system/xbin/which", "su" });


### PR DESCRIPTION
This removes both methods (above and below SDK version 23) for detecting root if build tag contains the string `'test-keys'`. It was causing false positives on non-rooted devices whose builds were signed with test-keys.

See https://github.com/GantMan/jail-monkey/issues/18 for more information.