### PR TITLE
React Native 0.52+ requires indication of main queue setup requirements

### DIFF
--- a/JailMonkey/JailMonkey.m
+++ b/JailMonkey/JailMonkey.m
@@ -14,6 +14,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (BOOL)canViolateSandbox{
 	NSError *error;
 	NSString *stringToBeWritten = @"This is an anti-spoofing test.";


### PR DESCRIPTION

Following React Native upgrade I get the following warning:

```
Module JailMonkey requires main queue setup since it overrides constantsToExport but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

Already applied in _many_ other plugins, like: 

  * https://github.com/airbnb/lottie-react-native/pull/226
  * https://github.com/luggit/react-native-config/pull/172