### PR TITLE
corrected trustFall

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ if (react.NativeModules && react.NativeModules.JailMonkey) {
 export default {
   isJailBroken: () => JailMonkey.isJailBroken,
   canMockLocation: () => JailMonkey.canMockLocation,
-  trustFall: () => !JailMonkey.isJailBroken && !JailMonkey.canMockLocation,
+  trustFall: () => JailMonkey.isJailBroken || JailMonkey.canMockLocation,
   isOnExternalStorage: () => JailMonkey.isOnExternalStorage
 }


### PR DESCRIPTION
trustFall is reporting true for a trustable device
`10-13 11:27:22.606 21125 21254 I ReactNativeJS: isJailBroken: false, canMockLocation:false, trustFall:true`

with this fix:
`10-13 11:39:37.035 21125 22603 I ReactNativeJS: isJailBroken: false, canMockLocation:false, trustFall:false`