### PR TITLE
Check root for Xiaomi without checking BusyBox

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -9,6 +9,7 @@ public class RootedCheck {
 
     private static final String ONEPLUS = "oneplus";
     private static final String MOTO = "moto";
+    private static final String XIAOMI = "Xiaomi";
 
     /**
      * Checks if the device is rooted.
@@ -29,7 +30,7 @@ public class RootedCheck {
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
         Boolean rv;
-        if(Build.BRAND.contains(ONEPLUS) || Build.BRAND.contains(MOTO)) {
+        if(Build.BRAND.contains(ONEPLUS) || Build.BRAND.contains(MOTO) || Build.BRAND.contains(XIAOMI)) {
             rv = rootBeer.isRootedWithoutBusyBoxCheck();
         } else {
             rv = rootBeer.isRooted();


### PR DESCRIPTION
Xiaomi devices are falsely evaluated as rooted because of the presence of BusyBox and should be bypassed for busybox checking