### PR TITLE
Fix NPE when ALLOW_MOCK_LOCATION is missing

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
@@ -7,7 +7,7 @@ public class MockLocationCheck {
 
     //returns true if mock location enabled, false if not enabled.
     public static boolean isMockLocationOn(Context context) {
-        if (Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ALLOW_MOCK_LOCATION).equals("0")) {
+        if ("0".equals(Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ALLOW_MOCK_LOCATION))) {
             return false;
         } else {
             return true;


### PR DESCRIPTION
This fixes #25 as described in the issue.
It would be really great if this could get merged as our app crashes currently on certain OnePlus devices.