### PR TITLE
Compare brand in a case-insensitive manner

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -9,7 +9,7 @@ public class RootedCheck {
 
     private static final String ONEPLUS = "oneplus";
     private static final String MOTO = "moto";
-    private static final String XIAOMI = "Xiaomi";
+    private static final String XIAOMI = "xiaomi";
 
     /**
      * Checks if the device is rooted.
@@ -30,7 +30,8 @@ public class RootedCheck {
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
         Boolean rv;
-        if(Build.BRAND.contains(ONEPLUS) || Build.BRAND.contains(MOTO) || Build.BRAND.contains(XIAOMI)) {
+        final String brand = Build.BRAND.toLowerCase();
+        if(brand.contains(ONEPLUS) || brand.contains(MOTO) || brand.contains(XIAOMI)) {
             rv = rootBeer.isRootedWithoutBusyBoxCheck();
         } else {
             rv = rootBeer.isRooted();


### PR DESCRIPTION
For example, the OnePlus 2’s brand name contains the string `OnePlus` as opposed to `oneplus`.