### PR TITLE
Expanded file list for the jailbreak test

### DIFF
--- a/JailMonkey/JailMonkey.m
+++ b/JailMonkey/JailMonkey.m
@@ -31,6 +31,34 @@ RCT_EXPORT_MODULE();
              @"/usr/sbin/sshd",
              @"/etc/apt",
              @"/private/var/lib/apt",
+             @"/usr/sbin/frida-server",
+             @"/usr/bin/cycript",
+             @"/usr/local/bin/cycript",
+             @"/usr/lib/libcycript.dylib",
+             @"/Applications/FakeCarrier.app",
+             @"/Applications/Icy.app",
+             @"/Applications/IntelliScreen.app",
+             @"/Applications/MxTube.app",
+             @"/Applications/RockApp.app",
+             @"/Applications/SBSettings.app",
+             @"/Applications/WinterBoard.app",
+             @"/Applications/blackra1n.app",
+             @"/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+             @"/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+             @"/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+             @"/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+             @"/bin/sh",
+             @"/etc/ssh/sshd_config",
+             @"/private/var/lib/cydia",
+             @"/private/var/mobile/Library/SBSettings/Themes",
+             @"/private/var/stash",
+             @"/private/var/tmp/cydia.log",
+             @"/usr/bin/sshd",
+             @"/usr/libexec/sftp-server",
+             @"/usr/libexec/ssh-keysign",
+             @"/var/cache/apt",
+             @"/var/lib/apt",
+             @"/var/lib/cydia",
              ];
 }
 
@@ -44,28 +72,28 @@ RCT_EXPORT_MODULE();
 - (BOOL)checkPaths
 {
     BOOL existsPath = NO;
-    
+
     for (NSString *path in [self pathsToCheck]) {
         if ([[NSFileManager defaultManager] fileExistsAtPath:path]){
             existsPath = YES;
             break;
         }
     }
-    
+
     return existsPath;
 }
 
 - (BOOL)checkSchemes
 {
     BOOL canOpenScheme = NO;
-    
+
     for (NSString *scheme in [self schemesToCheck]) {
         if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]){
             canOpenScheme = YES;
             break;
         }
     }
-    
+
     return canOpenScheme;
 }
 
@@ -79,9 +107,9 @@ RCT_EXPORT_MODULE();
 		//Device is jailbroken
 		grantsToWrite = YES;
 	}
-    
+
     [[NSFileManager defaultManager] removeItemAtPath:JMJailbreakTextFile error:nil];
-    
+
     return grantsToWrite;
 }
 


### PR DESCRIPTION
OWASP in the MSTG document ( the download can be done here: [https://github.com/OWASP/owasp-mstg/releases/download/1.1-excel/MSTG-EN.pdf](https://github.com/OWASP/owasp-mstg/releases/download/1.1-excel/MSTG-EN.pdf) , 392 is the relevant page ) suggests this list of paths to check (in addition to the existing one) in order to better understand if an iPhone is jailbroken or not.