### PR TITLE
Check root without busybox for all devices

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -7,10 +7,6 @@ import android.os.Build;
 
 public class RootedCheck {
 
-    private static final String ONEPLUS = "oneplus";
-    private static final String MOTO = "moto";
-    private static final String XIAOMI = "xiaomi";
-
     /**
      * Checks if the device is rooted.
      *
@@ -29,13 +25,7 @@ public class RootedCheck {
 
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
-        Boolean rv;
-        final String brand = Build.BRAND.toLowerCase();
-        if(brand.contains(ONEPLUS) || brand.contains(MOTO) || brand.contains(XIAOMI)) {
-            rv = rootBeer.isRootedWithoutBusyBoxCheck();
-        } else {
-            rv = rootBeer.isRooted();
-        }
-        return rv;
+        
+        return rootBeer.isRootedWithoutBusyBoxCheck();
     }
 }


### PR DESCRIPTION
Since some manufacturers leave the busybox binary present in the rom, it's better to use [`isRootedWithoutBusyBoxCheck()`](https://github.com/scottyab/rootbeer#false-positives) for all devices rather than specifying certain brands in order to avoid false positives.