### PR TITLE
Fixed support for android mock location detection on versions Marshmallow and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ react-native link
 
 If you use `rnpm`, you may have trouble as `rnpm` does not link Android properly after 0.29.0!
 
+Note: On Android you should include `location.isFromMockProvider()` from your location provider to compliment `JailMonkey.canMockLocation()`.  Most react-native location libraries already have this check built in
+
 # Additional Info
 This has been made public to help keep it up to date.  As detection measures get better or out-dated, please send updates to this project so it can be the best method of detection.
 

--- a/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
@@ -2,15 +2,52 @@ package com.gantix.JailMonkey.MockLocation;
 
 import android.content.Context;
 import android.provider.Settings;
+import android.os.Build;
+import android.util.Log;
+import com.facebook.react.bridge.ReactContext;
+import android.content.pm.PackageManager;
+
+import java.util.List;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PackageInfo;
+import android.location.LocationManager;
+
+import java.lang.IllegalArgumentException;
 
 public class MockLocationCheck {
-
-    //returns true if mock location enabled, false if not enabled.
     public static boolean isMockLocationOn(Context context) {
-        if ("0".equals(Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ALLOW_MOCK_LOCATION))) {
-            return false;
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return "0".equals(Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ALLOW_MOCK_LOCATION));
         } else {
-            return true;
+            PackageManager pm = context.getPackageManager();
+            List<ApplicationInfo> packages =
+                    pm.getInstalledApplications(PackageManager.GET_META_DATA);
+
+            for (ApplicationInfo applicationInfo : packages) {
+                try {
+                    PackageInfo packageInfo = pm.getPackageInfo(applicationInfo.packageName,
+                            PackageManager.GET_PERMISSIONS);
+
+                    // Get Permissions
+                    String[] requestedPermissions = packageInfo.requestedPermissions;
+
+                    if (requestedPermissions != null) {
+                        for (int i = 0; i < requestedPermissions.length; i++) {
+                            if (requestedPermissions[i]
+                                    .equals("android.permission.ACCESS_MOCK_LOCATION")
+                                    && !applicationInfo.packageName.equals(context.getPackageName())) {
+                                return true;
+                            }
+                        }
+                    }
+                } catch (NameNotFoundException e) {
+                    Log.e("Mock location check error ", e.getMessage());
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Looks like the existing check for mocked locations only works for Android version Lollipop and below.  I updated the check to look through current app permissions and check if location can be mocked in any of them.  

This check helps, but still doesn't 100% work.  In the case where the user were to:
1. have a location mocking app
2. set their location
3. delete their app
Their location will still be cached as a mocked location and none of the mocked location apps will be installed.  It really needs to have an additional check in the react native app's location library but since this package isn't tied to a specific location library this really isn't possible.  I added a note in the readme that you should use this check in addition to the `JailMonkey.canMockLocation()` call

fixes: https://github.com/GantMan/jail-monkey/issues/44

related: https://stackoverflow.com/questions/6880232/disable-check-for-mock-location-prevent-gps-spoofing
