### PR TITLE
Fix flow/ts types for non promise returning methods

### DIFF
--- a/jailmonkey.d.ts
+++ b/jailmonkey.d.ts
@@ -1,14 +1,13 @@
 // should be imported this way:
 // import JailMonkey from 'jail-monkey';
 
-
 declare const _default: {
-  isJailBroken: () => Promise<boolean>;
+  isJailBroken: () => boolean;
   isDebuggedMode: () => Promise<boolean>;
-  canMockLocation: () => Promise<boolean>;
-  trustFall: () => Promise<boolean>;
-  isOnExternalStorage: () => Promise<boolean>;
-  AdbEnabled: () => Promise<boolean>;
+  canMockLocation: () => boolean;
+  trustFall: () => boolean;
+  isOnExternalStorage: () => boolean;
+  AdbEnabled: () => boolean;
   isDevelopmentSettingsMode: () => Promise<boolean>;
 };
 

--- a/jailmonkey.js.flow
+++ b/jailmonkey.js.flow
@@ -1,11 +1,11 @@
 // @flow
 
 declare module.exports: {
-  isJailBroken: () => Promise<boolean>,
+  isJailBroken: () => boolean,
   isDebuggedMode: () => Promise<boolean>,
-  canMockLocation: () => Promise<boolean>,
-  trustFall: () => Promise<boolean>,
-  isOnExternalStorage: () => Promise<boolean>,
-  AdbEnabled: () => Promise<boolean>,
+  canMockLocation: () => boolean,
+  trustFall: () => boolean,
+  isOnExternalStorage: () => boolean,
+  AdbEnabled: () => boolean,
   isDevelopmentSettingsMode: () => Promise<boolean>,
 };


### PR DESCRIPTION
This PR updates the flow/ts types for several methods that don't return promises resolving to a boolean value but evaluate to return a boolean value directly.

eg. looking at isJailBroken() - the JS wrapper returns a constant value stored in the native code

ie.

````
isJailBroken: () => JailMonkey.isJailBroken
````

which is defined as a constant in native code in Objective-C (sic):

````
JMisJailBronkenKey: @(self.isJailBroken)
````

and in Java:

````
constants.put("isJailBroken", isJailBroken(context));
````

as opposed to isDevelopmentSettingsMode which is defined (only in Java) as a react method that does return a promise.

````
    @ReactMethod
    public void isDevelopmentSettingsMode(Promise p) {
````

Here we update:

isJailBroken, canMockLocation, trustFall, isOnExternalStorage, AdbEnabled

to all reflect that they return a method that evaluates to a boolean, and leave the others as they were.