### PR TITLE
Use correct React-Core dependency in podspec - fixes issues with Xcode 12

### DIFF
--- a/jail-monkey.podspec
+++ b/jail-monkey.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "JailMonkey/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
`React-Core` is the correct dependency to require for native libs, more information here: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116