### PR TITLE
Disabling jailbreak checks when app is running on Apple Silicon

### DIFF
--- a/JailMonkey/JailMonkey.m
+++ b/JailMonkey/JailMonkey.m
@@ -147,6 +147,13 @@ RCT_EXPORT_METHOD(isDebuggedMode:(RCTPromiseResolveBlock) resolve
     #if TARGET_OS_SIMULATOR
       return NO;
     #endif
+    BOOL isiOSAppOnMac = false;
+    if (@available(iOS 14.0, *)) {
+        isiOSAppOnMac = [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+    if (isiOSAppOnMac) {
+        return false;
+    }
     return [self checkPaths] || [self checkSchemes] || [self canViolateSandbox];
 }
 


### PR DESCRIPTION
Currently the library is showing a false positive when it's running on an Apple Silicon as some of the paths are exists on a normal Mac (e.g. /bin/bash).