### PR TITLE
Prevent null reference on packageManager.getInstalledApplications

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/HookDetection/HookDetectionCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/HookDetection/HookDetectionCheck.java
@@ -21,9 +21,11 @@ public class HookDetectionCheck {
         List<ApplicationInfo> applicationInfoList = packageManager.getInstalledApplications(PackageManager.GET_META_DATA);
         String[] dangerousPackages = {"de.robv.android.xposed.installer", "com.saurik.substrate", "de.robv.android.xposed"};
 
-        for (ApplicationInfo applicationInfo : applicationInfoList) {
-            if (Arrays.asList(dangerousPackages).contains(applicationInfo.packageName)) {
-                return true;
+        if (applicationInfoList != null) {
+            for (ApplicationInfo applicationInfo : applicationInfoList) {
+                if (Arrays.asList(dangerousPackages).contains(applicationInfo.packageName)) {
+                    return true;
+                }
             }
         }
 

--- a/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/MockLocation/MockLocationCheck.java
@@ -25,25 +25,27 @@ public class MockLocationCheck {
             List<ApplicationInfo> packages =
                     pm.getInstalledApplications(PackageManager.GET_META_DATA);
 
-            for (ApplicationInfo applicationInfo : packages) {
-                try {
-                    PackageInfo packageInfo = pm.getPackageInfo(applicationInfo.packageName,
-                            PackageManager.GET_PERMISSIONS);
+            if (packages != null) {
+                for (ApplicationInfo applicationInfo : packages) {
+                    try {
+                        PackageInfo packageInfo = pm.getPackageInfo(applicationInfo.packageName,
+                                PackageManager.GET_PERMISSIONS);
 
-                    // Get Permissions
-                    String[] requestedPermissions = packageInfo.requestedPermissions;
+                        // Get Permissions
+                        String[] requestedPermissions = packageInfo.requestedPermissions;
 
-                    if (requestedPermissions != null) {
-                        for (int i = 0; i < requestedPermissions.length; i++) {
-                            if (requestedPermissions[i]
-                                    .equals("android.permission.ACCESS_MOCK_LOCATION")
-                                    && !applicationInfo.packageName.equals(context.getPackageName())) {
-                                return true;
+                        if (requestedPermissions != null) {
+                            for (int i = 0; i < requestedPermissions.length; i++) {
+                                if (requestedPermissions[i]
+                                        .equals("android.permission.ACCESS_MOCK_LOCATION")
+                                        && !applicationInfo.packageName.equals(context.getPackageName())) {
+                                    return true;
+                                }
                             }
                         }
+                    } catch (NameNotFoundException e) {
+                        Log.e("Mock location check error ", e.getMessage());
                     }
-                } catch (NameNotFoundException e) {
-                    Log.e("Mock location check error ", e.getMessage());
                 }
             }
 


### PR DESCRIPTION
Whether there's a root app or xposed/magisk module that prevents us getting packageManager.getInstalledApplications or if the actual OEM's just aren't letting us fetch the information - it appears it just comes back as null on certain devices. I cna't think of any better way to circumvent this crash (Judging by our logs only Samsung devices - several newer note devices and several newer S-series devices.)