### PR TITLE
Removed rootbeer lib as it's causing false positives

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,4 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.scottyab:rootbeer-lib:0.0.9'
 }

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -2,7 +2,6 @@ package com.gantix.JailMonkey.Rooted;
 
 import android.content.Context;
 
-import com.scottyab.rootbeer.RootBeer;
 import android.os.Build;
 
 public class RootedCheck {
@@ -20,12 +19,6 @@ public class RootedCheck {
         } else {
             check = new LessThan23();
         }
-        return check.checkRooted() || rootBeerCheck(context);
-    }
-
-    private static boolean rootBeerCheck(Context context) {
-        RootBeer rootBeer = new RootBeer(context);
-        
-        return rootBeer.isRootedWithoutBusyBoxCheck();
+        return check.checkRooted();
     }
 }


### PR DESCRIPTION
This part of the library is causing some false positives. We've spotted this issue on a Samsung Galaxy S20+.
https://github.com/scottyab/rootbeer#false-positives

I tried to replace `rootBeer.isRootedWithBusyBoxCheck();` with `rootBeer.isRooted();` but that also has the same false positive on a Samsung Galaxy S20+. So I decided to remove that library entirely to get rid of this false positive. 

Not entirely sure if that's the right approach or shall we do some further checks now? I'm totally open for discussions here :) 