### PR TITLE
Expose android rooted detection methods results to JS

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
+++ b/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModule.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.gantix.JailMonkey.Rooted.RootedCheck;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,8 +22,6 @@ import static com.gantix.JailMonkey.AdbEnabled.AdbEnabled.AdbEnabled;
 import static com.gantix.JailMonkey.ExternalStorage.ExternalStorageCheck.isOnExternalStorage;
 import static com.gantix.JailMonkey.HookDetection.HookDetectionCheck.hookDetected;
 import static com.gantix.JailMonkey.MockLocation.MockLocationCheck.isMockLocationOn;
-import static com.gantix.JailMonkey.Rooted.RootedCheck.isJailBroken;
-
 
 public class JailMonkeyModule extends ReactContextBaseJavaModule {
 
@@ -70,8 +69,12 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
     public @Nullable
     Map<String, Object> getConstants() {
         ReactContext context = getReactApplicationContext();
+        final RootedCheck rootedCheck = new RootedCheck(context);
+
         final Map<String, Object> constants = new HashMap<>();
-        constants.put("isJailBroken", isJailBroken(context));
+
+        constants.put("isJailBroken", rootedCheck.isJailBroken());
+        constants.put("rootedDetectionMethods", rootedCheck.getResultByDetectionMethod());
         constants.put("hookDetected", hookDetected(context));
         constants.put("canMockLocation", isMockLocationOn(context));
         constants.put("isOnExternalStorage", isOnExternalStorage(context));

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -1,9 +1,8 @@
 package com.gantix.JailMonkey.Rooted;
 
+import static com.scottyab.rootbeer.Const.BINARY_SU;
 import android.content.Context;
-
 import com.scottyab.rootbeer.RootBeer;
-import android.os.Build;
 
 public class RootedCheck {
 
@@ -30,6 +29,8 @@ public class RootedCheck {
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
 
-        return rootBeer.isRootedWithoutBusyBoxCheck();
+        return rootBeer.detectRootManagementApps() || rootBeer.detectPotentiallyDangerousApps() || rootBeer.checkForBinary(BINARY_SU)
+                || rootBeer.checkForDangerousProps() || rootBeer.checkForRWPaths()
+                || rootBeer.detectTestKeys() || rootBeer.checkSuExists() || rootBeer.checkForRootNative() || rootBeer.checkForMagiskBinary();
     }
 }

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -11,7 +11,7 @@ public class RootedCheck {
      * @return <code>true</code> if the device is rooted, <code>false</code> otherwise.
      */
     public static boolean isJailBroken(Context context) {
-        return checkWithJailMonkeyMethod() || rootBeerCheck(context);
+        return new RootedCheck(context).isJailBroken();
     }
 
     private static boolean checkWithJailMonkeyMethod() {
@@ -25,8 +25,16 @@ public class RootedCheck {
         return check.checkRooted();
     }
 
-    private static boolean rootBeerCheck(Context context) {
-        return new RootBeerResults(context).isJailBroken();
+    private final boolean jailMonkeyResult;
+    private final RootBeerResults rootBeerResults;
+
+    public RootedCheck(Context context) {
+        jailMonkeyResult = checkWithJailMonkeyMethod();
+        rootBeerResults = new RootBeerResults(context);
+    }
+
+    public boolean isJailBroken() {
+        return jailMonkeyResult || rootBeerResults.isJailBroken();
     }
 
     private static class RootBeerResults {

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -2,18 +2,10 @@ package com.gantix.JailMonkey.Rooted;
 
 import android.content.Context;
 import com.scottyab.rootbeer.RootBeer;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RootedCheck {
-
-    /**
-     * Checks if the device is rooted.
-     *
-     * @return <code>true</code> if the device is rooted, <code>false</code> otherwise.
-     */
-    public static boolean isJailBroken(Context context) {
-        return new RootedCheck(context).isJailBroken();
-    }
-
     private static boolean checkWithJailMonkeyMethod() {
         CheckApiVersion check;
 
@@ -35,6 +27,15 @@ public class RootedCheck {
 
     public boolean isJailBroken() {
         return jailMonkeyResult || rootBeerResults.isJailBroken();
+    }
+
+    public Map<String, Object> getResultByDetectionMethod() {
+        final Map<String, Object> map = new HashMap<>();
+
+        map.put("jailMonkey", jailMonkeyResult);
+        map.put("rootBeer", rootBeerResults.toNativeMap());
+
+        return map;
     }
 
     private static class RootBeerResults {
@@ -67,6 +68,22 @@ public class RootedCheck {
             return detectRootManagementApps || detectPotentiallyDangerousApps || checkForSuBinary
                     || checkForDangerousProps || checkForRWPaths
                     || detectTestKeys || checkSuExists || checkForRootNative || checkForMagiskBinary;
+        }
+
+        public Map<String, Object> toNativeMap() {
+            final Map<String, Object> map = new HashMap<>();
+
+            map.put("detectRootManagementApps", detectRootManagementApps);
+            map.put("detectPotentiallyDangerousApps", detectPotentiallyDangerousApps);
+            map.put("checkForSuBinary", checkForSuBinary);
+            map.put("checkForDangerousProps", checkForDangerousProps);
+            map.put("checkForRWPaths", checkForRWPaths);
+            map.put("detectTestKeys", detectTestKeys);
+            map.put("checkSuExists", checkSuExists);
+            map.put("checkForRootNative", checkForRootNative);
+            map.put("checkForMagiskBinary", checkForMagiskBinary);
+
+            return map;
         }
     }
 }

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -1,6 +1,5 @@
 package com.gantix.JailMonkey.Rooted;
 
-import static com.scottyab.rootbeer.Const.BINARY_SU;
 import android.content.Context;
 import com.scottyab.rootbeer.RootBeer;
 
@@ -27,10 +26,39 @@ public class RootedCheck {
     }
 
     private static boolean rootBeerCheck(Context context) {
-        RootBeer rootBeer = new RootBeer(context);
+        return new RootBeerResults(context).isJailBroken();
+    }
 
-        return rootBeer.detectRootManagementApps() || rootBeer.detectPotentiallyDangerousApps() || rootBeer.checkForBinary(BINARY_SU)
-                || rootBeer.checkForDangerousProps() || rootBeer.checkForRWPaths()
-                || rootBeer.detectTestKeys() || rootBeer.checkSuExists() || rootBeer.checkForRootNative() || rootBeer.checkForMagiskBinary();
+    private static class RootBeerResults {
+        private final boolean detectRootManagementApps;
+        private final boolean detectPotentiallyDangerousApps;
+        private final boolean checkForSuBinary;
+        private final boolean checkForDangerousProps;
+        private final boolean checkForRWPaths;
+        private final boolean detectTestKeys;
+        private final boolean checkSuExists;
+        private final boolean checkForRootNative;
+        private final boolean checkForMagiskBinary;
+
+        RootBeerResults(Context context) {
+            final RootBeer rootBeer = new RootBeer(context);
+            rootBeer.setLogging(false);
+
+            detectRootManagementApps = rootBeer.detectRootManagementApps();
+            detectPotentiallyDangerousApps = rootBeer.detectPotentiallyDangerousApps();
+            checkForSuBinary = rootBeer.checkForSuBinary();
+            checkForDangerousProps = rootBeer.checkForDangerousProps();
+            checkForRWPaths = rootBeer.checkForRWPaths();
+            detectTestKeys = rootBeer.detectTestKeys();
+            checkSuExists = rootBeer.checkSuExists();
+            checkForRootNative = rootBeer.checkForRootNative();
+            checkForMagiskBinary = rootBeer.checkForMagiskBinary();
+        }
+
+        public boolean isJailBroken() {
+            return detectRootManagementApps || detectPotentiallyDangerousApps || checkForSuBinary
+                    || checkForDangerousProps || checkForRWPaths
+                    || detectTestKeys || checkSuExists || checkForRootNative || checkForMagiskBinary;
+        }
     }
 }

--- a/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/Rooted/RootedCheck.java
@@ -13,6 +13,10 @@ public class RootedCheck {
      * @return <code>true</code> if the device is rooted, <code>false</code> otherwise.
      */
     public static boolean isJailBroken(Context context) {
+        return checkWithJailMonkeyMethod() || rootBeerCheck(context);
+    }
+
+    private static boolean checkWithJailMonkeyMethod() {
         CheckApiVersion check;
 
         if (android.os.Build.VERSION.SDK_INT >= 23) {
@@ -20,12 +24,12 @@ public class RootedCheck {
         } else {
             check = new LessThan23();
         }
-        return check.checkRooted() || rootBeerCheck(context);
+        return check.checkRooted();
     }
 
     private static boolean rootBeerCheck(Context context) {
         RootBeer rootBeer = new RootBeer(context);
-        
+
         return rootBeer.isRootedWithoutBusyBoxCheck();
     }
 }

--- a/jailmonkey.d.ts
+++ b/jailmonkey.d.ts
@@ -4,6 +4,20 @@
 declare const _default: {
   jailBrokenMessage : () => string,
   isJailBroken: () => boolean;
+  androidRootedDetectionMethods?: {
+    rootBeer: {
+      detectRootManagementApps: boolean;
+      detectPotentiallyDangerousApps: boolean;
+      checkForSuBinary: boolean;
+      checkForDangerousProps: boolean;
+      checkForRWPaths: boolean;
+      detectTestKeys: boolean;
+      checkSuExists: boolean;
+      checkForRootNative: boolean;
+      checkForMagiskBinary: boolean;
+    },
+    jailMonkey: boolean;
+  };
   hookDetected: () => boolean;
   isDebuggedMode: () => Promise<boolean>;
   canMockLocation: () => boolean;

--- a/jailmonkey.js
+++ b/jailmonkey.js
@@ -7,6 +7,7 @@ if (JailMonkey == null) console.warn("JailMonkey is not available, check your na
 export default {
   jailBrokenMessage: () => JailMonkey.jailBrokenMessage || "",
   isJailBroken: () => JailMonkey.isJailBroken || false,
+  androidRootedDetectionMethods: JailMonkey.rootedDetectionMethods,
   hookDetected: () => JailMonkey.hookDetected || false,
   canMockLocation: () => JailMonkey.canMockLocation || false,
   trustFall: () =>

--- a/jailmonkey.js.flow
+++ b/jailmonkey.js.flow
@@ -3,6 +3,20 @@
 declare module.exports: {
   jailBrokenMessage: () => string,
   isJailBroken: () => boolean,
+  androidRootedDetectionMethods?: {
+    rootBeer: {
+      detectRootManagementApps: boolean;
+      detectPotentiallyDangerousApps: boolean;
+      checkForSuBinary: boolean;
+      checkForDangerousProps: boolean;
+      checkForRWPaths: boolean;
+      detectTestKeys: boolean;
+      checkSuExists: boolean;
+      checkForRootNative: boolean;
+      checkForMagiskBinary: boolean;
+    },
+    jailMonkey: boolean;
+  },
   hookDetected: () => boolean,
   isDebuggedMode: () => Promise<boolean>,
   canMockLocation: () => boolean,


### PR DESCRIPTION
This is a proposal to deal with issues like https://github.com/GantMan/jail-monkey/pull/102

In our case, we'd like to keep using this lib but keep some granularity on root beer methods, to be able to ignore those that seem to trigger most false positive cases.

Not entirely sure this is the best solution, but it should be retro-compatible (keeping the default `isJailBroken` value) and continues to expose constant values. The caveat is that it still runs all the checks, even the ones we don't use. One way to deal with that would be to completely change the lib behavior and expose async function to execute the detection methods instead of storing them in constants.