### PR TITLE
fix: get build.gradle values from rootProject and update default values

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    buildToolsVersion safeExtGet('buildToolsVersion', "31.0.0")
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
### Description

Gets the values for build.gradle options from rootProject. Also updated the default values to current react-native version values.

### Motivation and Context

If build.gradle options are different from rootProject it may not build.

### Related issues

#28 
I was getting the same error and the build was failing, because `compileSdkVersion` and `buildToolsVersion` were incompatible.