### PR TITLE
Remove `package` name from AndroidManfiest.xml to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,13 +5,9 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.gantix.JailMonkey'
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', "31.0.0")
-
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
-    if (agpVersion >= 7) {
-      namespace 'com.gantix.JailMonkey'
-    }
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.gantix.JailMonkey">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/android/src/main/java/com/gantix/JailMonkey/HookDetection/HookDetectionCheck.java
+++ b/android/src/main/java/com/gantix/JailMonkey/HookDetection/HookDetectionCheck.java
@@ -20,9 +20,9 @@ public class HookDetectionCheck {
         PackageManager packageManager = context.getPackageManager();
         List<ApplicationInfo> applicationInfoList = packageManager.getInstalledApplications(PackageManager.GET_META_DATA);
         String[] dangerousPackages = {
-                "de.robv.android.xposed.installer", 
-                "com.saurik.substrate", 
-                "de.robv.android.xposed"
+                "de.robv.android.xposed.installer",
+                "com.saurik.substrate",
+                "de.robv.android.xposed",
                 "com.noshufou.android.su.elite",
                 "eu.chainfire.supersu",
                 "com.koushikdutta.superuser",
@@ -45,7 +45,7 @@ public class HookDetectionCheck {
                 "eu.chainfire.supersu.pro",
                 "com.kingouser.com",
                 "com.topjohnwu.magisk"
-                };
+            };
 
         if (applicationInfoList != null) {
             for (ApplicationInfo applicationInfo : applicationInfoList) {


### PR DESCRIPTION
Remove the `package` manifest key to support AGP 8+

This means the library will now only support AGP 7+