### PR TITLE
fix: android auto link

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,30 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def supportsNamespace() {
+  def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+
+  // Namespace support was added in 7.3.0
+  if (major == 7 && minor >= 3) {
+    return true
+  }
+
+  return major >= 8
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.gantix.JailMonkey'
+    if (supportsNamespace()) {
+        namespace 'com.gantix.JailMonkey'
+        sourceSets {
+          main {
+            manifest.srcFile "src/main/AndroidManifestNew.xml"
+          }
+        }
+    }
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', "31.0.0")
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.gantix.JailMonkey">
 </manifest>

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>


### PR DESCRIPTION
React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. This will require all the libraries to specify a namespace in their build.gradle file. But this changes effect under 0.73 version users so I added backward compability.

related react native discussions: https://github.com/react-native-community/discussions-and-proposals/issues/671


https://github.com/GantMan/jail-monkey/issues/340
https://github.com/GantMan/jail-monkey/issues/323