### PR TITLE
add detection for dopamine2 hide-jailbreak

### DIFF
--- a/JailMonkey/JailMonkey.m
+++ b/JailMonkey/JailMonkey.m
@@ -100,7 +100,8 @@ RCT_EXPORT_MODULE();
             @"/var/lib/dpkg/info/mobilesubstrate.md5sums",
             @"/var/log/apt",
             @"/var/mobile/Library/Preferences/me.jjolano.shadow.plist",
-            @"/var/mobile/Library/Preferences/ABPattern"
+            @"/var/mobile/Library/Preferences/ABPattern",
+            @"/var/mobile/Library/Preferences/com.opa334.Dopamine-roothide.plist"
             ];
 }
 


### PR DESCRIPTION
file link: https://github.com/roothide/Dopamine2-roothide/blob/05ae073414fcddec674c2cecc589187ced4f86b9/Application/Dopamine/Jailbreak/DOPreferenceManager.m#L26 

related issue: https://github.com/GantMan/jail-monkey/issues/344