### PR TITLE
fix: rootedDetectionMethods crashes on new arch due to nested HashMap cast

### DIFF
--- a/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModuleImpl.java
+++ b/android/src/main/java/com/gantix/JailMonkey/JailMonkeyModuleImpl.java
@@ -93,6 +93,7 @@ public class JailMonkeyModuleImpl {
         return com.gantix.JailMonkey.HookDetection.HookDetectionCheck.hookDetected(context);
     }
 
+    @SuppressWarnings("unchecked")
     public static WritableMap rootedDetectionMethods() {
         RootedCheck rootedCheck = new RootedCheck(context);
         Map<String, Object> result = rootedCheck.getResultByDetectionMethod();
@@ -100,7 +101,18 @@ public class JailMonkeyModuleImpl {
         WritableMap map = Arguments.createMap();
 
         for (Map.Entry<String, Object> entry : result.entrySet()) {
-            map.putBoolean(entry.getKey(), (Boolean) entry.getValue());
+            Object value = entry.getValue();
+            if (value instanceof Boolean) {
+                map.putBoolean(entry.getKey(), (Boolean) value);
+            } else if (value instanceof Map) {
+                WritableMap nestedMap = Arguments.createMap();
+                for (Map.Entry<String, Object> nested : ((Map<String, Object>) value).entrySet()) {
+                    if (nested.getValue() instanceof Boolean) {
+                        nestedMap.putBoolean(nested.getKey(), (Boolean) nested.getValue());
+                    }
+                }
+                map.putMap(entry.getKey(), nestedMap);
+            }
         }
 
         return map;

--- a/android/src/oldarch/java/com/gantix/JailMonkey/JailMonkeyModule.java
+++ b/android/src/oldarch/java/com/gantix/JailMonkey/JailMonkeyModule.java
@@ -12,11 +12,9 @@ import javax.annotation.Nullable;
 
 public class JailMonkeyModule extends ReactContextBaseJavaModule {
 
-    private final JailMonkeyModuleImpl impl;
-
     public JailMonkeyModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        impl = new JailMonkeyModuleImpl(reactContext);
+        JailMonkeyModuleImpl.init(reactContext);
     }
 
     @Override
@@ -26,25 +24,24 @@ public class JailMonkeyModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void isDevelopmentSettingsMode(Promise p) {
-        impl.isDevelopmentSettingsMode(p);
+        JailMonkeyModuleImpl.isDevelopmentSettingsMode(p);
     }
 
     @ReactMethod
     public void isDebuggedMode(Promise p) {
-        impl.isDebuggedMode(p);
+        JailMonkeyModuleImpl.isDebuggedMode(p);
     }
 
-    @ReactMethod
     @Override
     public @Nullable Map<String, Object> getConstants() {
         Map<String, Object> constants = new HashMap<>();
 
-        constants.put("isJailBroken", impl.isJailBroken());
-        constants.put("hookDetected", impl.hookDetected());
-        constants.put("canMockLocation", impl.canMockLocation());
-        constants.put("isOnExternalStorage", impl.isOnExternalStorage());
-        constants.put("AdbEnabled", impl.isAdbEnabled());
-        constants.put("rootedDetectionMethods", rootedCheck.getResultByDetectionMethod());
+        constants.put("isJailBroken", JailMonkeyModuleImpl.isJailBroken());
+        constants.put("hookDetected", JailMonkeyModuleImpl.hookDetected());
+        constants.put("canMockLocation", JailMonkeyModuleImpl.canMockLocation());
+        constants.put("isOnExternalStorage", JailMonkeyModuleImpl.isOnExternalStorage());
+        constants.put("AdbEnabled", JailMonkeyModuleImpl.isAdbEnabled());
+        constants.put("rootedDetectionMethods", JailMonkeyModuleImpl.rootedDetectionMethods());
 
         return constants;
     }

--- a/jailmonkey.d.ts
+++ b/jailmonkey.d.ts
@@ -4,7 +4,8 @@
 declare const _default: {
   jailBrokenMessage : () => string,
   isJailBroken: () => boolean;
-  androidRootedDetectionMethods?: {
+  rootedDetectionMethods?: () => {
+    jailMonkey: boolean;
     rootBeer: {
       detectRootManagementApps: boolean;
       detectPotentiallyDangerousApps: boolean;
@@ -15,8 +16,7 @@ declare const _default: {
       checkSuExists: boolean;
       checkForRootNative: boolean;
       checkForMagiskBinary: boolean;
-    },
-    jailMonkey: boolean;
+    };
   };
   hookDetected: () => boolean;
   isDebuggedMode: () => Promise<boolean>;

--- a/specs/NativeJailMonkey.ts
+++ b/specs/NativeJailMonkey.ts
@@ -11,7 +11,20 @@ export interface Spec extends TurboModule {
   AdbEnabled(): boolean;
   isDebuggedMode(): Promise<boolean>;
   isDevelopmentSettingsMode(): Promise<boolean>;
-  rootedDetectionMethods?: () => { [key: string]: boolean };
+  rootedDetectionMethods?: () => {
+    jailMonkey: boolean;
+    rootBeer: {
+      detectRootManagementApps: boolean;
+      detectPotentiallyDangerousApps: boolean;
+      checkForSuBinary: boolean;
+      checkForDangerousProps: boolean;
+      checkForRWPaths: boolean;
+      detectTestKeys: boolean;
+      checkSuExists: boolean;
+      checkForRootNative: boolean;
+      checkForMagiskBinary: boolean;
+    };
+  };
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(


### PR DESCRIPTION
## Problem

`rootedDetectionMethods()` crashes on the new architecture (TurboModules) with:

```
Exception in HostFunction: java.util.HashMap cannot be cast to java.lang.Boolean
```

### Root cause

`JailMonkeyModuleImpl.rootedDetectionMethods()` iterates over the result of `RootedCheck.getResultByDetectionMethod()` and casts every value to `Boolean`:

```java
for (Map.Entry<String, Object> entry : result.entrySet()) {
    map.putBoolean(entry.getKey(), (Boolean) entry.getValue());
}
```

But `getResultByDetectionMethod()` returns:
- `"jailMonkey"` → `boolean` ✅
- `"rootBeer"` → `HashMap<String, Object>` ❌ (cannot cast to Boolean)

### Additional issues found

1. **Old-arch `JailMonkeyModule.getConstants()`** references undefined `rootedCheck` field instead of using `JailMonkeyModuleImpl` statics — this would fail to compile or crash at runtime
2. **`NativeJailMonkey.ts` spec** declares return type as flat `{ [key: string]: boolean }` instead of the actual nested structure
3. **`jailmonkey.d.ts`** uses `androidRootedDetectionMethods` as the property name, but `index.tsx` exports it as `rootedDetectionMethods`

## Fix

- Handle nested maps in `rootedDetectionMethods()` with `instanceof` checks and `putMap()` for nested entries
- Fix old-arch module to use `JailMonkeyModuleImpl` static methods consistently
- Update TurboModule spec with correct nested return type
- Fix `.d.ts` to match the actual exported API name and type it as a function

## Test plan

- [ ] Build on Android with new architecture — `rootedDetectionMethods()` returns `{ jailMonkey: boolean, rootBeer: { ... } }` without crash
- [ ] Build on Android with old architecture — `getConstants()` works with `JailMonkeyModuleImpl` statics
- [ ] TypeScript consumers can use `JailMonkey.rootedDetectionMethods?.()` with correct types

🤖 Generated with [Claude Code](https://claude.com/claude-code)